### PR TITLE
Added alternative symfony/console versions (~3.0 and ~4.0).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
+  - 7.1
+  - 7.2
   - hhvm
 
 before_script: composer install --dev --prefer-source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+CHANGELOG
+=========
+
+master
+------
+
+* Added alternative `symfony/console` versions (`~3.0` and `~4.0`).
+* Removed PHP versions < `5.6`.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.3",
         "guzzle/guzzle": "~3.7",
-        "symfony/console": "~2.5"
+        "symfony/console": "~2.5|~3.0|~4.0"
     },
     "require-dev":{
         "phpunit/phpunit": "~4.1"

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": "^5.6 || ^7.1",
         "guzzle/guzzle": "~3.7",
         "symfony/console": "~2.5|~3.0|~4.0"
     },


### PR DESCRIPTION
I added alternative `symfony/console` versions (~3.0 and ~4.0).

I develop project [PHP Censor](https://github.com/php-censor/php-censor) which use your library and it use `symfony/console` v3.4.*. Could you release new version (I guess: `1.0.1`) of library after the pull request merge please?