### PR TITLE
Returned PHP v7.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "mremi/flowdock",
     "type": "library",
-    "description": "A PHP5 library to interact with the Flowdock API",
+    "description": "A PHP library to interact with the Flowdock API",
     "keywords": ["flowdock", "api"],
     "homepage": "https://github.com/mremi/Flowdock",
     "license": "MIT",
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.1",
+        "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0",
         "symfony/console": "~2.5|~3.0|~4.0"
     },


### PR DESCRIPTION
Can we retern PHP `v7.0`? Firstly it works on `v7.0`. Secondly projects wich depend on the library can support PHP versions like `>=5.6.0`. What do you think about it?